### PR TITLE
单端口多用户限速无效修正

### DIFF
--- a/shadowsocks/tcprelay.py
+++ b/shadowsocks/tcprelay.py
@@ -1779,10 +1779,11 @@ class TCPRelay(object):
                     self.multi_user_table[id][
                         '_forbidden_portset'] = PortRange(str(""))
 
-        if 'node_speedlimit' not in config or 'users_table' in self._config:
-            self.bandwidth = 0
-        else:
-            self.bandwidth = float(config['node_speedlimit']) * 128
+        if not hasattr(self, 'bandwidth') or self.bandwidth == 0:
+            if 'node_speedlimit' not in config: # or 'users_table' in self._config:
+                self.bandwidth = 0
+            else:
+                self.bandwidth = float(config['node_speedlimit']) * 128
 
         self.speed_tester_u = SpeedTester(self.bandwidth)
         self.speed_tester_d = SpeedTester(self.bandwidth)


### PR DESCRIPTION
Hi, esdeathlove

这个代码是修正限速对单端口多用户端口无效的问题。
个人自己测试OK（自己的server跑了几个月，没发现副作用），今天又有一位网友测试OK，所以提交一个补丁。

因为不懂python，所以有任何语法或者用法问题请见谅。